### PR TITLE
Added .mif file support

### DIFF
--- a/src/main/java/mars/mips/dump/MIFDumpFormat.java
+++ b/src/main/java/mars/mips/dump/MIFDumpFormat.java
@@ -4,6 +4,7 @@ import mars.Globals;
 import mars.mips.hardware.*;
 
 import java.io.*;
+import java.nio.file.Files;
 /*
 Copyright (c) 2003-2008,  Pete Sanderson and Kenneth Vollmar
 
@@ -37,20 +38,32 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * This is documented for the Altera platform at
  * www.altera.com/support/software/nativelink/quartus2/glossary/def_mif.html.
  *
- * @author Pete Sanderson
- * @version December 2007
+ * @author Pete Sanderson, Modified by Sandro Lortkipanidze
+ * @version October 2024
  */
+public class MIFDumpFormat extends AbstractDumpFormat {
 
-// NOT READY FOR PRIME TIME.  WHEN IT IS, UNCOMMENT THE "extends" CLAUSE
-// AND THE SUPERCLASS CONSTRUCTOR CALL SO THE FORMAT LOADER WILL ACCEPT IT
-// AND IT WILL BE ADDED TO THE LIST.
-public class MIFDumpFormat { // extends AbstractDumpFormat {
+    public enum Format {
+        BIN, HEX, OCT, DEC, UNS
+    }
+
+    private Format addressFormat;
+    private Format dataFormat;
+
+    public MIFDumpFormat() {
+        super("MIF", "MIF", "Written as Memory Initialization File (Altera)", "mif");
+        configure(Format.HEX, Format.HEX); // Default configuration
+    }
 
     /**
-     * Constructor.  File extention is "mif".
+     * Configure the output format for address and data.
+     *
+     * @param addressFormat Format for address output
+     * @param dataFormat    Format for data output
      */
-    public MIFDumpFormat() {
-        //   super("MIF", "MIF", "Written as Memory Initialization File (Altera)", "mif");
+    public void configure(Format addressFormat, Format dataFormat) {
+        this.addressFormat = addressFormat;
+        this.dataFormat = dataFormat;
     }
 
     /**
@@ -58,15 +71,55 @@ public class MIFDumpFormat { // extends AbstractDumpFormat {
      * (MIF) specification.
      *
      * @param file         File in which to store MIPS memory contents.
-     * @param firstAddress first (lowest) memory address to dump.  In bytes but
+     * @param firstAddress first (lowest) memory address to dump. In bytes but
      *                     must be on word boundary.
-     * @param lastAddress  last (highest) memory address to dump.  In bytes but
-     *                     must be on word boundary.  Will dump the word that starts at this address.
+     * @param lastAddress  last (highest) memory address to dump. In bytes but
+     *                     must be on word boundary. Will dump the word that starts at this address.
      * @throws AddressErrorException if firstAddress is invalid or not on a word boundary.
      * @throws IOException           if error occurs during file output.
      */
-    public void dumpMemoryRange(File file, int firstAddress, int lastAddress)
-            throws AddressErrorException, IOException {
+    public void dumpMemoryRange(File file, int firstAddress, int lastAddress) throws AddressErrorException, IOException {
+        try (PrintStream out = new PrintStream(Files.newOutputStream(file.toPath()))) {
+            out.println("DEPTH = " + ((lastAddress - firstAddress) / Memory.WORD_LENGTH_BYTES + 1) + ";");
+            out.println("WIDTH = 32;");
+            out.println("ADDRESS_RADIX = " + addressFormat.name() + ";");
+            out.println("DATA_RADIX = " + dataFormat.name() + ";");
+            out.println("CONTENT");
+            out.println("BEGIN");
 
+            for (int address = firstAddress; address <= lastAddress; address += Memory.WORD_LENGTH_BYTES) {
+                Integer temp = Globals.memory.getRawWordOrNull(address);
+                if (temp == null)
+                    break;
+                out.println("\t"+formatAddress((address - firstAddress) / Memory.WORD_LENGTH_BYTES) + " : " + formatData(temp) + ";");
+            }
+
+            out.println("END;");
+        }
+    }
+
+    private String formatAddress(int address) {
+        return formatValue(address, addressFormat);
+    }
+
+    private String formatData(int data) {
+        return formatValue(data, dataFormat);
+    }
+
+    private String formatValue(int value, Format format) throws IllegalArgumentException {
+        switch (format) {
+            case BIN:
+                return String.format("%32s", Integer.toBinaryString(value)).replace(' ', '0');
+            case HEX:
+                return String.format("%8s", Integer.toHexString(value)).replace(' ', '0');
+            case OCT:
+                return String.format("%11s", Integer.toOctalString(value)).replace(' ', '0');
+            case DEC:
+                return String.valueOf(value);
+            case UNS:
+                return String.valueOf(Integer.toUnsignedLong(value));
+            default:
+                throw new IllegalArgumentException("Invalid format: " + format);
+        }
     }
 }


### PR DESCRIPTION
In the original MARS software, this was started but not implemented.

MIF (Memory Initialization File) is used a more human-readable alternative to .hex format. Both of these may be used to load initial memory on Intel/Altera boards.

This version supports configuration of the formats used. It can support Hex, Binary, Decimal, etc. UI end of configuration can be added in the future.